### PR TITLE
fix(ui): enhance text color for better visibility in ChatInput component

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -79,7 +79,7 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             className={`w-full resize-none rounded-lg py-3 pl-4 pr-12 ${
               disabled
                 ? "bg-gray-100 dark:bg-gray-800 text-gray-500"
-                : "bg-white dark:bg-gray-900"
+                : "bg-white dark:bg-gray-900 dark:text-white"
             } border border-gray-200 dark:border-gray-700 focus:border-blue-500 dark:focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 dark:focus:ring-blue-400/20`}
             rows={1}
             style={{


### PR DESCRIPTION
This pull request includes a small change to the `ChatInput` component in the `src/components/ChatInput.tsx` file. The change ensures that the text color is set to white when the dark mode is enabled.

* [`src/components/ChatInput.tsx`](diffhunk://#diff-1996a5e45995f5849cbcea7a39299aa1a96cc0fa41b1401e503d4891bbe686c1L82-R82): Updated the `className` property to include `dark:text-white` for better readability in dark mode.